### PR TITLE
HOWTO: Correct MBR + UEFI comparison as MBR/BIOS + GPT/UEFI

### DIFF
--- a/HOWTO
+++ b/HOWTO
@@ -6,8 +6,8 @@ It assumes a working knowledge of Linux, including how to mount, partition, and
 format hard disks.
 
 Wren is presently built around Ubuntu Desktop 14.04.1 LTS 32-bit. The 32-bit
-version has better system compatibility and boots using MBR instead of UEFI by
-default.
+version has better system compatibility and partitions/boots using MBR/BIOS
+instead of GPT/UEFI.
 
 The Ubuntu 14.04.1 LTS 32-bit LiveCD does not presently support loop devices.
 The Wren builder (wrender) requires loop devices, so Wren cannot be built from


### PR DESCRIPTION
The HOWTO (and the wiki Installation Guide) somewhat incorrectly compare MBR and UEFI. While they are (correctly) separate, MBR deals with the storage of partition information while UEFI is responsible for handling machine startup. MBR storage is used by the (legacy) BIOS. GPT is the partition storage system used by the newer UEFI.

To keep things similarly short, I changed the HOWTO to read "The 32-bit version has better system compatibility and partitions/boots using MBR/BIOS instead of GPT/UEFI."
