### PR TITLE
save.sh + update-grub.sh: Remove incorrect copyright information

### DIFF
--- a/copy/save.sh
+++ b/copy/save.sh
@@ -95,14 +95,6 @@ OPTIONS
                         provided, the current default save file path will be
                         used instead.
 
-AUTHOR
-
-    Written by Michael Spencer.
-
-COPYRIGHT
-
-    Copyright (c) 2013-2015 Trynd, LLC.
-
 EOF
 
     test x"$1" != x && exit $1

--- a/copy/update-grub.sh
+++ b/copy/update-grub.sh
@@ -49,14 +49,6 @@ DESCRIPTION
 
     Writes a new grub.cfg file to match current device save data to standard
     output. Use redirection to write to a file.
-
-AUTHOR
-
-    Written by Michael Spencer.
-
-COPYRIGHT
-
-    Copyright (c) 2013-2015 Trynd, LLC.
 "
 printUsage()
 {


### PR DESCRIPTION
This removes author and copyright information from the usage display functions in `save.sh` and `update-grub.sh`.

When the project started, it was assumed that Trynd would hold the copyright. We opted to use the GPL so this was not the case. The script headers are correct, but the copyright lines were never removed from the usage display functions in the `save.sh` and `update-grub.sh` scripts.
