### PR TITLE
Add platform version and display name to default environment variables

### DIFF
--- a/platform-env
+++ b/platform-env
@@ -30,17 +30,17 @@
 # more details.
 #
 
-# Define the platform name.
+# Define the platform name (no whitespace allowed).
 if test x"$RUN_ENV_PLATFORM_NAME" = x; then
     RUN_ENV_PLATFORM_NAME=wren
 fi
 
 # Define the platform's display name.
 if test x"$RUN_ENV_PLATFORM_DISPLAY_NAME" = x; then
-    RUN_ENV_PLATFORM_DISPLAY_NAME=Wren
+    RUN_ENV_PLATFORM_DISPLAY_NAME="Wren"
 fi
 
-# Define the platform version.
+# Define the platform version (no whitespace allowed).
 RUN_ENV_PLATFORM_VERSION=0.1.0
 
 # Define mount points.

--- a/wrender
+++ b/wrender
@@ -332,8 +332,8 @@ STEP DESCRIPTIONS (IN ORDER OF BUILD STEPS)
           should include the platform environment, tools, and utility scripts
           as well as a copy of the source directory used to perform the build.
 
-        * Add the new platform environment's name to the chroot (union mounted)
-          system's environment variables.
+        * Add the new platform environment's name and version to the chroot
+          (union mounted) system's environment variables.
 
     UNINSTALL
 
@@ -823,6 +823,7 @@ test -f "$path_dir_source/conf/platform.conf" \
     || fail "Unable to load required source file: \"conf/platform.conf\""
 for i in \
     RUN_ENV_PLATFORM_NAME \
+    RUN_ENV_PLATFORM_DISPLAY_NAME \
     RUN_ENV_PLATFORM_VERSION \
     PLATFORM_IMAGE_PLATFORM \
     PLATFORM_IMAGE_KERNEL \
@@ -1021,11 +1022,27 @@ if test x"$should_copy" = x1; then
         fi
     done
 
-    # add the running platform name to the system's environment variables
+    # add system environment variables
     path_environment=$path_dir_tmp/$name_dir_union/etc/environment
-    grep "RUN_ENV_PLATFORM_NAME=" "$path_environment" 1>/dev/null 2>&1 \
-        || echo "RUN_ENV_PLATFORM_NAME=$RUN_ENV_PLATFORM_NAME" >>"$path_environment" \
-        || fail "Unable to update the environment file: \"$path_environment\""
+    if test -f "$path_environment"; then
+    
+      # add the running platform name to the system's environment variables
+      echo "RUN_ENV_PLATFORM_NAME=\"$RUN_ENV_PLATFORM_NAME\"" >>"$path_environment" \
+          || fail "Unable to update the environment file: \"$path_environment\""
+
+      # add the running platform version to the system's environment variables
+      echo "RUN_ENV_PLATFORM_VERSION=\"$RUN_ENV_PLATFORM_VERSION\"" >>"$path_environment" \
+          || fail "Unable to update the environment file: \"$path_environment\""
+    
+      # add the running platform display name to the system's environment variables
+      echo "RUN_ENV_PLATFORM_DISPLAY_NAME=\"$RUN_ENV_PLATFORM_DISPLAY_NAME\"" >>"$path_environment" \
+          || fail "Unable to update the environment file: \"$path_environment\""
+
+    else
+
+      fail "Unable to locate the environment file: \"$path_environment\""
+
+    fi
 
     # add an exception to the sudoers file to retain the running platform name
     # environment variable when using sudo


### PR DESCRIPTION
This adds the platform version (`$RUN_ENV_PLATFORM_VERSION`) and display name (`$RUN_ENV_PLATFORM_DISPLAY_NAME`) to the default environment variables in the `/etc/environment` file.

It's particularly useful to be able to check the platform version from the command line without having to source the `platform-env` file. The additional display name could be useful for external applications.
