### PR TITLE
Implement new RUN_ENV_PLATFORM_PATH variable

### DIFF
--- a/copy/increase-save-size.sh
+++ b/copy/increase-save-size.sh
@@ -40,12 +40,12 @@ PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
 
 # ensure platform name is defined
-test x"${RUN_ENV_PLATFORM_NAME}" = x \
-    && { echo "Could not determine platform environment name - exiting..." >&2 ; exit 1 ; }
+test x"${RUN_ENV_PLATFORM_PATH}" = x \
+    && { echo "Could not determine platform environment path - exiting..." >&2 ; exit 1 ; }
 
 
 # load platform environment
-. "/etc/${RUN_ENV_PLATFORM_NAME}/platform-env" \
+. "${RUN_ENV_PLATFORM_PATH}/platform-env" \
     || { echo "Could not load platform environment - exiting..." >&2 ; exit 1 ; }
 
 

--- a/copy/save.sh
+++ b/copy/save.sh
@@ -102,12 +102,12 @@ EOF
 
 
 # ensure platform name is defined
-test x"${RUN_ENV_PLATFORM_NAME}" = x \
-    && { echo "Could not determine platform environment name - exiting..." >&2 ; exit 1 ; }
+test x"${RUN_ENV_PLATFORM_PATH}" = x \
+    && { echo "Could not determine platform environment path - exiting..." >&2 ; exit 1 ; }
 
 
 # load platform environment
-. "/etc/${RUN_ENV_PLATFORM_NAME}/platform-env" \
+. "${RUN_ENV_PLATFORM_PATH}/platform-env" \
     || { echo "Could not load platform environment - exiting..." >&2 ; exit 1 ; }
 
 

--- a/copy/update-grub.sh
+++ b/copy/update-grub.sh
@@ -66,11 +66,15 @@ fail()
 }
 
 # load platform environment
-test x"$RUN_ENV_PLATFORM_NAME" != x \
-    && . "/etc/$RUN_ENV_PLATFORM_NAME/platform-env" \
+test x"$RUN_ENV_PLATFORM_PATH" != x \
+    && . "$RUN_ENV_PLATFORM_PATH/platform-env" \
     && loadRunEnvConf \
     && updateBootOptions \
     || fail "Unable to load platform environment"
+
+# ensure platform name
+testVariableDefinition RUN_ENV_PLATFORM_NAME \
+    || fail "Unable to determine platform name"
 
 # ensure platform display name
 testVariableDefinition RUN_ENV_PLATFORM_DISPLAY_NAME \

--- a/platform-env
+++ b/platform-env
@@ -30,18 +30,14 @@
 # more details.
 #
 
-# Define the platform name (no whitespace allowed).
-if test x"$RUN_ENV_PLATFORM_NAME" = x; then
-    RUN_ENV_PLATFORM_NAME=wren
-fi
+# Define the platform name and version (no whitespace allowed).
+RUN_ENV_PLATFORM_NAME=wren
+RUN_ENV_PLATFORM_VERSION=0.1.1
 
-# Define the platform's display name.
+# Define the platform's display name if not defined externally.
 if test x"$RUN_ENV_PLATFORM_DISPLAY_NAME" = x; then
     RUN_ENV_PLATFORM_DISPLAY_NAME="Wren"
 fi
-
-# Define the platform version (no whitespace allowed).
-RUN_ENV_PLATFORM_VERSION=0.1.1
 
 # Define mount points.
 MOUNT_ENV=/mnt/$RUN_ENV_PLATFORM_NAME

--- a/setlist
+++ b/setlist
@@ -36,21 +36,21 @@
 # Common platform run environment variables are allowed.
 # If a path or filename contains spaces, make sure to backslash (\) the spaces.
 SETLIST_COPY="
-    /etc/${RUN_ENV_PLATFORM_NAME}                                   -
-    /etc/${RUN_ENV_PLATFORM_NAME}/COPYRIGHT                         COPYRIGHT
-    /etc/${RUN_ENV_PLATFORM_NAME}/LICENSE                           LICENSE
-    /etc/${RUN_ENV_PLATFORM_NAME}/boot.conf.example                 conf/boot.conf
-    /etc/${RUN_ENV_PLATFORM_NAME}/device.conf.example               conf/device.conf
-    /etc/${RUN_ENV_PLATFORM_NAME}/grub.cfg.example                  conf/grub.cfg
-    /etc/${RUN_ENV_PLATFORM_NAME}/increase-save-size.sh             copy/increase-save-size.sh
-    /etc/${RUN_ENV_PLATFORM_NAME}/platform-env                      platform-env
-    /etc/${RUN_ENV_PLATFORM_NAME}/platform.conf.example             conf/platform.conf
-    /etc/${RUN_ENV_PLATFORM_NAME}/save.sh                           copy/save.sh
-    /etc/${RUN_ENV_PLATFORM_NAME}/tools                             -
-    /etc/${RUN_ENV_PLATFORM_NAME}/tools/enable-root.sh              tools/enable-root.sh
-    /etc/${RUN_ENV_PLATFORM_NAME}/tools/disable-root.sh             tools/disable-root.sh
-    /etc/${RUN_ENV_PLATFORM_NAME}/tools/rename-user.sh              tools/rename-user.sh
-    /etc/${RUN_ENV_PLATFORM_NAME}/update-grub.sh                    copy/update-grub.sh
+    ${RUN_ENV_PLATFORM_PATH}                                        -
+    ${RUN_ENV_PLATFORM_PATH}/COPYRIGHT                              COPYRIGHT
+    ${RUN_ENV_PLATFORM_PATH}/LICENSE                                LICENSE
+    ${RUN_ENV_PLATFORM_PATH}/boot.conf.example                      conf/boot.conf
+    ${RUN_ENV_PLATFORM_PATH}/device.conf.example                    conf/device.conf
+    ${RUN_ENV_PLATFORM_PATH}/grub.cfg.example                       conf/grub.cfg
+    ${RUN_ENV_PLATFORM_PATH}/increase-save-size.sh                  copy/increase-save-size.sh
+    ${RUN_ENV_PLATFORM_PATH}/platform-env                           platform-env
+    ${RUN_ENV_PLATFORM_PATH}/platform.conf.example                  conf/platform.conf
+    ${RUN_ENV_PLATFORM_PATH}/save.sh                                copy/save.sh
+    ${RUN_ENV_PLATFORM_PATH}/tools                                  -
+    ${RUN_ENV_PLATFORM_PATH}/tools/enable-root.sh                   tools/enable-root.sh
+    ${RUN_ENV_PLATFORM_PATH}/tools/disable-root.sh                  tools/disable-root.sh
+    ${RUN_ENV_PLATFORM_PATH}/tools/rename-user.sh                   tools/rename-user.sh
+    ${RUN_ENV_PLATFORM_PATH}/update-grub.sh                         copy/update-grub.sh
     /etc/apt/preferences.d/no-bootloader                            copy/no-bootloader
     /etc/apt/preferences.d/no-misc                                  copy/no-misc
     /etc/initramfs-tools/modules                                    copy/modules

--- a/wrender
+++ b/wrender
@@ -1074,12 +1074,16 @@ if test x"$should_copy" = x1; then
 
     fi
 
-    # add an exception to the sudoers file to retain the running platform name
-    # environment variable when using sudo
+    # add an exception to the sudoers file to retain the running platform's
+    # environment variables when using sudo
     path_sudoers=$path_dir_tmp/$name_dir_union/etc/sudoers
     chmod u+w "$path_sudoers"
     echo '
 Defaults env_keep += "RUN_ENV_PLATFORM_NAME"' \
+        >>"$path_sudoers" \
+        || fail "Unable to update the sudoers file: \"$path_sudoers\""
+    echo '
+Defaults env_keep += "RUN_ENV_PLATFORM_PATH"' \
         >>"$path_sudoers" \
         || fail "Unable to update the sudoers file: \"$path_sudoers\""
     chmod u-w "$path_sudoers"

--- a/wrender
+++ b/wrender
@@ -96,6 +96,10 @@ OPTIONS
 
     --help,-h           OPTIONAL - Print this usage information and exit.
 
+    --package           OPTIONAL - The name of the directory into which the
+                        platform-layer application files will be installed.
+                        If this is not defined, the platform name is assumed.
+
     --platform,-p       OPTIONAL - Path to the existing platform file to use as
                         a basis for the newly created platform (essentially
                         updates an existing platform image).
@@ -105,6 +109,10 @@ OPTIONS
     --platform-mount    OPTIONAL - Path to a platform tree directory. This can
                         be used in place of --platform to specify an existing
                         platform tree directory location.
+
+    --prefix            OPTIONAL - Path to the directory under which the
+                        platform's package directory should be installed.
+                        If this is not defined, '/etc' is assumed.
 
     --root,-r           REQUIRED - Path to the root image to be used in the
                         chroot environment. Without this image it would be
@@ -124,7 +132,7 @@ OPTIONS
 
     --tmp,-t            OPTIONAL - Path to the temporary directory to use for
                         building the platform files. If this option is not
-                        specified '/tmp/platform' is assumed.
+                        specified, '/tmp/platform' is assumed.
 
 STEP-SPECIFIC OPTIONS (NOTE: ORDER MATTERS)
 
@@ -335,6 +343,9 @@ STEP DESCRIPTIONS (IN ORDER OF BUILD STEPS)
         * Add the new platform environment's name and version to the chroot
           (union mounted) system's environment variables.
 
+        * Add the new platform environment's install path to the chroot (union
+          mounted) system's environment variables.
+
     UNINSTALL
 
         These modifications will be a part of the exported platform image.
@@ -412,12 +423,16 @@ fail()
 
 pwd=`pwd`
 
+default_prefix=/etc
+
 default_path_dir_tmp=/tmp/platform
 name_dir_root=1-root
 name_dir_export=2-export
 name_dir_union=3-union
 name_dir_platform=xx-platform
 
+prefix=""
+package=""
 path_dir_source=""
 path_dir_destination=""
 path_dir_tmp=""
@@ -436,6 +451,8 @@ should_build=""
 should_export=""
 should_clean=""
 
+flag_prefix=0
+flag_package=0
 flag_dir_source=0
 flag_dir_destination=0
 flag_dir_tmp=0
@@ -447,6 +464,14 @@ flag_img_platform=0
 # load options
 for i in "$@"; do
     case 1 in
+        $flag_prefix )
+            prefix=$i
+            flag_prefix=0
+            ;;
+        $flag_package )
+            package=$i
+            flag_package=0
+            ;;
         $flag_dir_source )
             path_dir_source=$i
             flag_dir_source=0
@@ -480,45 +505,39 @@ for i in "$@"; do
 
                 ### OPTIONS
 
-                --destination|-d )
-                    flag_dir_destination=1
-                    ;;
-                -d* )
-                    path_dir_destination=${i#-d}
-                    ;;
-                --help|-h )
-                    printUsage 0
-                    ;;
-                --platform|-p )
-                    flag_img_platform=1
-                    ;;
-                -p* )
-                    path_img_platform=${i#-p}
-                    ;;
-                --platform-mount )
-                    flag_dir_platform=1
-                    ;;
-                --root|-r )
-                    flag_img_root=1
-                    ;;
-                -r* )
-                    path_img_root=${i#-r}
-                    ;;
-                --root-mount )
-                    flag_dir_root=1
-                    ;;
-                --source|-s )
-                    flag_dir_source=1
-                    ;;
-                -s* )
-                    path_dir_source=${i#-s}
-                    ;;
-                --tmp|-t )
-                    flag_dir_tmp=1
-                    ;;
-                -t* )
-                    path_dir_tmp=${i#-t}
-                    ;;
+                --destination|-d )      flag_dir_destination=1 ;;
+                --destination=* )       path_dir_destination=${i#--destination=} ;;
+                -d* )                   path_dir_destination=${i#-d} ;;
+                                        
+                --help|-h )             printUsage 0 ;;
+
+                --package )             flag_package=1 ;;
+                --package=* )           package=${i#--package=} ;;
+                                        
+                --platform|-p )         flag_img_platform=1 ;;
+                --platform=* )          path_img_platform=${i#--platform=} ;;
+                -p* )                   path_img_platform=${i#-p} ;;
+
+                --platform-mount )      flag_dir_platform=1 ;;
+                --platform-mount=* )    path_dir_platform=${i#--platform-mount=} ;;
+
+                --prefix )              flag_prefix=1 ;;
+                --prefix=* )            prefix=${i#--prefix=} ;;
+
+                --root|-r )             flag_img_root=1 ;;
+                --root=* )              path_img_root=${i#--root=} ;;
+                -r* )                   path_img_root=${i#-r} ;;
+
+                --root-mount )          flag_dir_root=1 ;;
+                --root-mount=* )        path_dir_root=${i#--root-mount=} ;;
+
+                --source|-s )           flag_dir_source=1 ;;
+                --source=* )            path_dir_source=${i#--source=} ;;
+                -s* )                   path_dir_source=${i#-s} ;;
+
+                --tmp|-t )              flag_dir_tmp=1 ;;
+                --tmp=* )               path_dir_tmp=${i#--tmp=} ;;
+                -t* )                   path_dir_tmp=${i#-t} ;;
 
                 ### STEP OPTIONS
 
@@ -754,6 +773,7 @@ test x"$should_export" = x      && should_export=$default_should
 test x"$should_clean" = x       && should_clean=$default_should
 
 # assign defaults for other unset options
+test x"$prefix" = x                 && prefix=$default_prefix
 test x"$path_dir_source" = x        && path_dir_source=`dirname $0`
 test x"$path_dir_destination" = x   && path_dir_destination=$pwd/build
 test x"$path_dir_tmp" = x           && path_dir_tmp=$default_path_dir_tmp
@@ -814,6 +834,7 @@ echo '---------------'
 echo
 
 # platform-env
+RUN_ENV_PLATFORM_PATH=""
 RUN_ENV_PLATFORM_NAME=""
 test -f "$path_dir_source/platform-env" \
     && . "$path_dir_source/platform-env" \
@@ -832,6 +853,10 @@ do
     eval "test x\"\$$i\" = x" \
         && fail "Required variable not defined by source files: $i"
 done
+
+# install path
+test x"$package" = x && package=$RUN_ENV_PLATFORM_NAME
+RUN_ENV_PLATFORM_PATH=${prefix%/}/$package
 
 # setlist
 SETLIST_COPY=""
@@ -1037,6 +1062,11 @@ if test x"$should_copy" = x1; then
       # add the running platform display name to the system's environment variables
       echo "RUN_ENV_PLATFORM_DISPLAY_NAME=\"$RUN_ENV_PLATFORM_DISPLAY_NAME\"" >>"$path_environment" \
           || fail "Unable to update the environment file: \"$path_environment\""
+
+        # add the running platform path ro the system's environment variables
+        grep "^RUN_ENV_PLATFORM_PATH=" "$path_environment" 1>/dev/null 2>&1 \
+            || echo "RUN_ENV_PLATFORM_PATH=\"$RUN_ENV_PLATFORM_PATH\"" >>"$path_environment" \
+            || fail "Unable to update the environment file: \"$path_environment\""
 
     else
 


### PR DESCRIPTION
Addresses issue #18 (_Replace environment's RUN_ENV_PLATFORM_NAME with RUN_ENV_PLATFORM_PATH_).

I updated `wrender` with two new options: `--prefix` and `--package`. These are used to determine the new `RUN_ENV_PLATFORM_PATH` variable which is also the directory the files are copied into. Currently `--prefix` defaults to `/etc` and `--package` defaults to `$RUN_ENV_PLATFORM_NAME` from `platform-env`. When combined they form a default `RUN_ENV_PLATFORM_PATH` of `/etc/wren`.

The `setlist` has been updated to use the new path variable.

All project scripts were updated to load their platform environment (`platform-env`) using the new path variable.

`wrender` adds the new path variable to the `/etc/environment` file, and this is **the only** place the variable (`RUN_ENV_PLATFORM_PATH`) is defined.
