### PR TITLE
setlist: Remove increase-save-size.sh

### DIFF
--- a/setlist
+++ b/setlist
@@ -39,7 +39,6 @@ SETLIST_COPY="
     $RUN_ENV_PLATFORM_PATH                                          -
     $RUN_ENV_PLATFORM_PATH/COPYRIGHT                                COPYRIGHT
     $RUN_ENV_PLATFORM_PATH/LICENSE                                  LICENSE
-    $RUN_ENV_PLATFORM_PATH/bin/increase-save-size.sh                copy/bin/increase-save-size.sh
     $RUN_ENV_PLATFORM_PATH/bin/save.sh                              copy/bin/save.sh
     $RUN_ENV_PLATFORM_PATH/bin/update-grub.sh                       copy/bin/update-grub.sh
     $RUN_ENV_PLATFORM_PATH/bin/wren                                 copy/bin/wren


### PR DESCRIPTION
`increase-save-size.sh` was entirely removed in version 0.2.0. This doesn't cause a build failure, but does throw a warning during the build process. Removing the `setlist` line for `increase-save-size.sh` eliminates the warning.
