### PR TITLE
Option to disable active data file system

### DIFF
--- a/copy/bin/wren
+++ b/copy/bin/wren
@@ -411,6 +411,7 @@ $memory_info
 EOF
     fi
 
+    # unallocated memory (active file system only)
     USAGE_MEMORY_UNALLOCATED=0
     if test -n "$USAGE_MEMORY_FREE"; then
         USAGE_MEMORY_UNALLOCATED=$(($USAGE_MEMORY_FREE - ${USAGE_ACTIVE_FREE:-0}))

--- a/copy/bin/wren
+++ b/copy/bin/wren
@@ -91,7 +91,7 @@ OPTIONS
 
     +active     Allot additional memory to increase the platform's active
                 storage capacity (when using active storage).
-                
+
                 Can also be used to check if an increase is \"necessary\"
                 and/or \"safe\".
 
@@ -117,7 +117,7 @@ OPTIONS
                                 Use this in combination with a BYTE_COUNT to
                                 test the \"safe\" status of a specific size
                                 increment.
-                                
+
                                 Returns a binary mask exit code:
 
                                     0 = safe and necessary
@@ -138,7 +138,7 @@ OPTIONS
     get         Retrieve a stored variable value. Requires a variable name.
 
     grub        Perform a Grub configuration SUBCOMMAND.
-    
+
                 Requires one SUBCOMMAND from the following:
 
                     generate    Display a new Grub configuration to standard
@@ -156,21 +156,21 @@ OPTIONS
                 using the \"write\" SUBCOMMAND.
 
     list        Display stored variables and their values.
-    
+
                 Used primarily for debugging purposes.
-    
+
                 Accepts one SUBCOMMAND from the following:
 
                     all         Display all known variables, even if they
                                 are not set or stored.
 
     save        Save to disk (or a target save file).
-    
+
                 Accepts one OPTION in the following format:
-                
+
                     save savename=\"name_of_save_on_disk\"
                     save savefile=\"/path/to/save/file\"
-                    
+
                 If no OPTION is provided, set variables or system defaults
                 will be used.
 
@@ -188,7 +188,7 @@ OPTIONS
 
     status      Report on current platform state and expected paths/values.
                 Accepts an optional SUBCOMMAND to retrieve a specific state.
-                
+
                 Accepted SUBCOMMAND values are:
 
                     all         Display all states (default).
@@ -253,7 +253,7 @@ PLATFORM_DEFAULT_SAVE=""
 loadRunEnvConf || panicExit
 updateBootOptions || panicExit
 
-# make a decision whether the system booted directly from a save image
+# decide whether the system booted directly from a save image
 if test x"$BOOT_SAVE_TO_RAM" = x1; then
     is_save_file=0
 else
@@ -261,9 +261,20 @@ else
     is_save_file=1
 fi
 
+# decide whether there is a separate active data storage file system
+if test x"$BOOT_NO_ACTIVE_FS" = x1; then
+    is_active_fs=0
+else
+    BOOT_NO_ACTIVE_FS=0
+    if test x"$is_save_file" = x0; then
+        is_active_fs=1
+    else
+        is_active_fs=0
+    fi
+fi
+
 # script paths
 CMD_SAVE=${RUN_ENV_PLATFORM_PATH}/bin/save.sh
-CMD_INCREASE_SAVE_SIZE=${RUN_ENV_PLATFORM_PATH}/bin/increase-save-size.sh
 CMD_UPDATE_GRUB=${RUN_ENV_PLATFORM_PATH}/bin/update-grub.sh
 
 # Other paths
@@ -420,7 +431,7 @@ case "$command" in
                     esac
                 fi
 
-                # show "all" variables or only those that are set 
+                # show "all" variables or only those that are set
                 test "$option" = all -o -n "$SAVENAME" && echo "savename=$SAVENAME"
                 test "$option" = all -o -n "$SAVEFILE" && echo "savefile=$SAVEFILE"
                 ;;
@@ -474,7 +485,7 @@ case "$command" in
                     panicExit "Option \"set\" requires a variable and a value"
                 fi
                 ;;
-                
+
     #
     # unset - unassign and remove stored variable values
     #
@@ -643,6 +654,12 @@ case "$command" in
                     USAGE_SAVE_TOTAL=-
                     USAGE_SAVE_USED=-
                     USAGE_SAVE_FREE=-
+
+                    if test "$is_active_fs" = 0; then
+                        USAGE_ACTIVE_TOTAL=-
+                        USAGE_ACTIVE_USED=-
+                        USAGE_ACTIVE_FREE=-
+                    fi
                 else
                     USAGE_ACTIVE_TOTAL=-
                     USAGE_ACTIVE_USED=-
@@ -737,7 +754,7 @@ case "$command" in
                         ""
                 esac
                 ;;
-                
+
     #
     # save - store active storage content to a save file
     #
@@ -804,9 +821,9 @@ case "$command" in
     #
     # +active - alot additional RAM to increase the active storage capacity
     #
-    +active )   # only valid when using active storage
-                test "$is_save_file" != 0 \
-                    && panicExit "Option \"+active\" is only valid when using active storage"
+    +active )   # only valid when using an active storage file system
+                test "$is_save_file" != 0 -o "$is_active_fs" = 0\
+                    && panicExit "Option \"+active\" is only valid when using an active storage file system"
 
                 testVariableDefinition MOUNT_SAVE || panicExit
                 testVariableDefinition PLATFORM_IMAGE_VOLUME_ACTIVE_SIZE_INCREMENT || panicExit

--- a/copy/bin/wren
+++ b/copy/bin/wren
@@ -187,8 +187,9 @@ OPTIONS
                     savefile, savename
 
     status      Report on current platform state and expected paths/values.
-                Accepts an optional SUBCOMMAND to retrieve a specific state.
+                Use \"-h\" or \"--human\" for human readable values.
 
+                Accepts an optional SUBCOMMAND to retrieve a specific state.
                 Accepted SUBCOMMAND values are:
 
                     all         Display all states (default).
@@ -209,6 +210,14 @@ OPTIONS
 
                     store       \"active\" or \"save\" depending on whether
                                 the save-to-ram feature was used at boot time.
+
+                    storefs     The file system used by the current store.
+
+                    storepath   The directory path under which store files may
+                                be found.
+
+                    storesize   The size of the content currently in the store
+                                directory.
 
     unset       Unassign and remove a stored variable. Requires a variable
                 name.
@@ -375,21 +384,26 @@ EOF
     fi
 
     # active/save storage information
-    active_info=$(df -B1 "$MOUNT_SAVE" | tail -n 1 | tr -s ' ' | cut -d ' ' -f 2-4) || return $?
-    if test -n "$active_info"; then
-        if IFS=' ' read a b c; then
-            if test "$is_save_file" = 0; then
-                USAGE_ACTIVE_TOTAL=$a
-                USAGE_ACTIVE_USED=$b
-                USAGE_ACTIVE_FREE=$c
-            else
-                USAGE_SAVE_TOTAL=$a
-                USAGE_SAVE_USED=$b
-                USAGE_SAVE_FREE=$c
-            fi
-        fi <<EOF
+    testVariableDefinition MOUNT_SAVE || panicExit
+    if test "$is_active_fs" != 0; then
+        active_info=$(df -B1 "$MOUNT_SAVE" | tail -n 1 | tr -s ' ' | cut -d ' ' -f 2-4) || return $?
+        if test -n "$active_info"; then
+            if IFS=' ' read a b c; then
+                if test "$is_save_file" = 0; then
+                    USAGE_ACTIVE_TOTAL=$a
+                    USAGE_ACTIVE_USED=$b
+                    USAGE_ACTIVE_FREE=$c
+                else
+                    USAGE_SAVE_TOTAL=$a
+                    USAGE_SAVE_USED=$b
+                    USAGE_SAVE_FREE=$c
+                fi
+            fi <<EOF
 $active_info
 EOF
+        fi
+    else
+        USAGE_ACTIVE_USED=$(du -bd0 "$MOUNT_SAVE" | tr -s '\t' ' ' | cut -d ' ' -f 1) || return $?
     fi
 
     # memory (ram + swap) information
@@ -501,9 +515,16 @@ case "$command" in
     #
     # status - report on current platform state and expected paths/values
     #
-    status )    # check for invalid options
+    status )    # check for modifier
+                modifier=$3
+                case "$option" in -h | --human )
+                    modifier=$option
+                    option=$3
+                esac
+
+                # check for invalid options
                 case "$option" in
-                    '' | all | platform | device | store | savename | savefile | savenames ) ;;
+                    '' | all | platform | device | store | storedir | storesize | storefs | savename | savefile | savenames ) ;;
                     * ) panicExit "Unknown \"status\" option: $option" ;;
                 esac
 
@@ -561,6 +582,39 @@ case "$command" in
                     else
                         echo "save"
                     fi
+                esac
+
+                # storefs
+                case "$option" in storefs | all )
+                    testVariableDefinition MOUNT_SAVE || panicExit
+                    if testIsMounted "$MOUNT_SAVE"; then
+                        storefs=$(cat /proc/mounts | tr -s '\t' ' ' | cut -d ' ' -f 2-3 | grep "^$MOUNT_SAVE" | cut -d ' ' -f 2) \
+                            || panicExit
+                    else
+                        storefs=tmpfs
+                    fi
+                    test "$option" = all && printf "$format_label" "storefs:"
+                    echo "$storefs"
+                esac
+
+                # storepath
+                case "$option" in storepath | all )
+                    testVariableDefinition MOUNT_SAVE || panicExit
+                    test "$option" = all && printf "$format_label" "storepath:"
+                    echo "$MOUNT_SAVE"
+                esac
+
+                # storesize
+                case "$option" in storesize | all )
+                    testVariableDefinition MOUNT_SAVE || panicExit
+                    storesize=$(du -bd0 "$MOUNT_SAVE" | tr -s '\t' ' ' | cut -d ' ' -f 1) \
+                        || panicExit
+                    case "$modifier" in -h | --human )
+                        storesize=$(bytesToHuman "$storesize") \
+                            || panicExit
+                    esac
+                    test "$option" = all && printf "$format_label" "storesize:"
+                    echo "$storesize"
                 esac
 
                 # savename
@@ -657,7 +711,6 @@ case "$command" in
 
                     if test "$is_active_fs" = 0; then
                         USAGE_ACTIVE_TOTAL=-
-                        USAGE_ACTIVE_USED=-
                         USAGE_ACTIVE_FREE=-
                     fi
                 else
@@ -688,9 +741,11 @@ case "$command" in
                     USAGE_MEMORY_FREE=$(bytesToHuman "$USAGE_MEMORY_FREE")
                     USAGE_MEMORY_UNALLOCATED=$(bytesToHuman "$USAGE_MEMORY_UNALLOCATED")
                     if test "$is_save_file" = 0; then
-                        USAGE_ACTIVE_TOTAL=$(bytesToHuman "$USAGE_ACTIVE_TOTAL")
                         USAGE_ACTIVE_USED=$(bytesToHuman "$USAGE_ACTIVE_USED")
-                        USAGE_ACTIVE_FREE=$(bytesToHuman "$USAGE_ACTIVE_FREE")
+                        if test "$is_active_fs" != 0; then
+                            USAGE_ACTIVE_TOTAL=$(bytesToHuman "$USAGE_ACTIVE_TOTAL")
+                            USAGE_ACTIVE_FREE=$(bytesToHuman "$USAGE_ACTIVE_FREE")
+                        fi
                     else
                         USAGE_SAVE_TOTAL=$(bytesToHuman "$USAGE_SAVE_TOTAL")
                         USAGE_SAVE_USED=$(bytesToHuman "$USAGE_SAVE_USED")

--- a/copy/bin/wren
+++ b/copy/bin/wren
@@ -385,7 +385,9 @@ EOF
 
     # active/save storage information
     testVariableDefinition MOUNT_SAVE || panicExit
-    if test "$is_active_fs" != 0; then
+    if test "$is_save_file" != 0 \
+        -o "$is_active_fs" != 0
+    then
         active_info=$(df -B1 "$MOUNT_SAVE" | tail -n 1 | tr -s ' ' | cut -d ' ' -f 2-4) || return $?
         if test -n "$active_info"; then
             if IFS=' ' read a b c; then
@@ -403,7 +405,7 @@ $active_info
 EOF
         fi
     else
-        USAGE_ACTIVE_USED=$(du -bd0 "$MOUNT_SAVE" | tr -s '\t' ' ' | cut -d ' ' -f 1) || return $?
+        USAGE_ACTIVE_USED=$(du -B1 -d0 "$MOUNT_SAVE" | tr -s '\t' ' ' | cut -d ' ' -f 1) || return $?
     fi
 
     # memory (ram + swap) information
@@ -607,7 +609,7 @@ case "$command" in
                 # storesize
                 case "$option" in storesize | all )
                     testVariableDefinition MOUNT_SAVE || panicExit
-                    storesize=$(du -bd0 "$MOUNT_SAVE" | tr -s '\t' ' ' | cut -d ' ' -f 1) \
+                    storesize=$(du -B1 -d0 "$MOUNT_SAVE" | tr -s '\t' ' ' | cut -d ' ' -f 1) \
                         || panicExit
                     case "$modifier" in -h | --human )
                         storesize=$(bytesToHuman "$storesize") \

--- a/copy/bin/wren
+++ b/copy/bin/wren
@@ -73,7 +73,7 @@ DESCRIPTION
 SYNOPSIS
 
     $APP_NAME <-h|--help>
-    $APP_NAME <COMMAND> [SUBCOMMAND|OPTION] [-v]
+    $APP_NAME <COMMAND> [SUBCOMMAND|OPTION] [OPTION]
 
     $APP_NAME +active [BYTE_COUNT] [--check|--force] [-v]
     $APP_NAME get <VARIABLE>
@@ -81,7 +81,8 @@ SYNOPSIS
     $APP_NAME list [all]
     $APP_NAME save [savename=<SAVE_NAME>|savefile=</PATH/TO/FILE>] [-v]
     $APP_NAME set <VARIABLE> <VALUE>
-    $APP_NAME status [all|device|platform|savefile|savename|savenames]
+    $APP_NAME status [all|device|platform|savefile|savename|savenames|store|
+        storefs|storepath|storesize] [-h|--human]
     $APP_NAME unset <VARIABLE>
     $APP_NAME usage [all|active|device|memory] [-h|--human]
 
@@ -262,24 +263,14 @@ PLATFORM_DEFAULT_SAVE=""
 loadRunEnvConf || panicExit
 updateBootOptions || panicExit
 
-# decide whether the system booted directly from a save image
-if test x"$BOOT_SAVE_TO_RAM" = x1; then
-    is_save_file=0
-else
-    BOOT_SAVE_TO_RAM=0
+# determine whether the system booted its active data store
+# with a known system image file
+is_active_fs=0
+is_save_file=0
+if testIsActiveImageActiveVolume; then
+    is_active_fs=1
+elif testIsActiveImageSave; then
     is_save_file=1
-fi
-
-# decide whether there is a separate active data storage file system
-if test x"$BOOT_NO_ACTIVE_FS" = x1; then
-    is_active_fs=0
-else
-    BOOT_NO_ACTIVE_FS=0
-    if test x"$is_save_file" = x0; then
-        is_active_fs=1
-    else
-        is_active_fs=0
-    fi
 fi
 
 # script paths

--- a/copy/etc/boot.conf
+++ b/copy/etc/boot.conf
@@ -81,3 +81,9 @@ BOOT_SAVE=
 # extra swap space may be required to store larger images.
 BOOT_SWAP=
 BOOT_SWAP_WAIT=10
+
+# The BOOT_NO_ACTIVE_FS option, if enabled, skips the creation of a separate
+# active file system image all together, instead falling back to storing active
+# data directly in the tmpfs mount. Note that this will make it impossible to
+# use snapshots during the save process.
+BOOT_NO_ACTIVE_FS=0

--- a/copy/initramfs/initramfs-script
+++ b/copy/initramfs/initramfs-script
@@ -215,32 +215,6 @@ then
 else
 
     testVariableDefinition MOUNT_TMP                                     || panicExit
-    testVariableDefinition PLATFORM_IMAGE_VOLUME_ACTIVE_SIZE_DEFAULT     || panicExit
-    testVariableDefinition PLATFORM_IMAGE_VOLUME_ACTIVE_SIZE_INCREMENT   || panicExit
-    testVariableDefinition PLATFORM_IMAGE_VOLUME_ACTIVE_RESIZE_TOLERANCE || panicExit
-    testVariableDefinition PLATFORM_IMAGE_VOLUME_ACTIVE_MOUNT_OPTIONS    || panicExit
-    testVariableDefinition PLATFORM_FILESYSTEM_READWRITE_JOURNALED       || panicExit
-    testVariableDefinition PLATFORM_FILESYSTEM_READWRITE_VOLUME          || panicExit
-
-
-    # determine active volume storage size
-    image_volume_active_size=$PLATFORM_IMAGE_VOLUME_ACTIVE_SIZE_DEFAULT
-    if test -x"$image_save" != x -a -f "$image_save"; then
-
-        # get device save file disk usage
-        device_image_save_size=`getDiskUsage "$image_save"` || panicExit
-
-        # increase size by resize tolerance to allow for expansion
-        device_image_save_size=$(($device_image_save_size+$PLATFORM_IMAGE_VOLUME_ACTIVE_RESIZE_TOLERANCE)) \
-            || panicExit
-
-        # increment storage size until it can hold what's on the device
-        while test "$image_volume_active_size" -lt "$device_image_save_size"; do
-            image_volume_active_size=$(($image_volume_active_size+$PLATFORM_IMAGE_VOLUME_ACTIVE_SIZE_INCREMENT)) \
-                || panicExit
-        done
-
-    fi
 
 
     # create temporary tmpfs union as a working chroot environment
@@ -253,28 +227,59 @@ else
     done
 
 
-    # create, format, and mount the active volume
-    image_volume_active=`getActiveVolumeImagePath` || panicExit
-    chroot "$MOUNT_TMP" dd if=/dev/zero of="$image_volume_active" \
-        bs=1 seek="$image_volume_active_size" count=0 1>/dev/null \
-        || panicExit
-    chroot "$MOUNT_TMP" mkfs.btrfs "$image_volume_active" 1>/dev/null \
-        || panicExit
-    volume_active=`getActiveVolumePath` || panicExit
-    mkdir -p "$volume_active" || panicExit
-    loop_volume_active=`losetup -f` || panicExit
-    mountImage "$PLATFORM_FILESYSTEM_READWRITE_VOLUME" \
-        "rw,$PLATFORM_IMAGE_VOLUME_ACTIVE_MOUNT_OPTIONS" \
-        "$image_volume_active" "$volume_active" "$loop_volume_active" \
-        || panicExit
+    if test x"$BOOT_NO_ACTIVE_FS" != x1; then
+
+        testVariableDefinition PLATFORM_IMAGE_VOLUME_ACTIVE_SIZE_DEFAULT     || panicExit
+        testVariableDefinition PLATFORM_IMAGE_VOLUME_ACTIVE_SIZE_INCREMENT   || panicExit
+        testVariableDefinition PLATFORM_IMAGE_VOLUME_ACTIVE_RESIZE_TOLERANCE || panicExit
+        testVariableDefinition PLATFORM_IMAGE_VOLUME_ACTIVE_MOUNT_OPTIONS    || panicExit
+        testVariableDefinition PLATFORM_FILESYSTEM_READWRITE_VOLUME          || panicExit
 
 
-    # create active volume's root subvolume and bind-mount it as the save store
-    volume_active_subvolume_root=`getActiveVolumeRootSubvolumePath` \
-        || panicExit
-    btrfs subvolume create "$volume_active_subvolume_root" 1>/dev/null \
-        || panicExit
-    mount --bind "$volume_active_subvolume_root" "$MOUNT_SAVE" || panicExit
+        # determine active volume storage size
+        image_volume_active_size=$PLATFORM_IMAGE_VOLUME_ACTIVE_SIZE_DEFAULT
+        if test x"$image_save" != x -a -f "$image_save"; then
+
+            # get device save file disk usage
+            device_image_save_size=`getDiskUsage "$image_save"` || panicExit
+
+            # increase size by resize tolerance to allow for expansion
+            device_image_save_size=$(($device_image_save_size+$PLATFORM_IMAGE_VOLUME_ACTIVE_RESIZE_TOLERANCE)) \
+                || panicExit
+
+            # increment storage size until it can hold what's on the device
+            while test "$image_volume_active_size" -lt "$device_image_save_size"; do
+                image_volume_active_size=$(($image_volume_active_size+$PLATFORM_IMAGE_VOLUME_ACTIVE_SIZE_INCREMENT)) \
+                    || panicExit
+            done
+
+        fi
+
+
+        # create, format, and mount the active volume
+        image_volume_active=`getActiveVolumeImagePath` || panicExit
+        chroot "$MOUNT_TMP" dd if=/dev/zero of="$image_volume_active" \
+            bs=1 seek="$image_volume_active_size" count=0 1>/dev/null \
+            || panicExit
+        chroot "$MOUNT_TMP" mkfs.btrfs "$image_volume_active" 1>/dev/null \
+            || panicExit
+        volume_active=`getActiveVolumePath` || panicExit
+        mkdir -p "$volume_active" || panicExit
+        loop_volume_active=`losetup -f` || panicExit
+        mountImage "$PLATFORM_FILESYSTEM_READWRITE_VOLUME" \
+            "rw,$PLATFORM_IMAGE_VOLUME_ACTIVE_MOUNT_OPTIONS" \
+            "$image_volume_active" "$volume_active" "$loop_volume_active" \
+            || panicExit
+
+
+        # create active volume's root subvolume and bind-mount it as the save store
+        volume_active_subvolume_root=`getActiveVolumeRootSubvolumePath` \
+            || panicExit
+        btrfs subvolume create "$volume_active_subvolume_root" 1>/dev/null \
+            || panicExit
+        mount --bind "$volume_active_subvolume_root" "$MOUNT_SAVE" || panicExit
+
+    fi
 
 
     # if there's a save image we need to copy its content to the ram save store
@@ -319,6 +324,7 @@ else
         losetup "$loop_save" 1>/dev/null 2>&1 \
             && { unloopLoop "$loop_save" || panicExit ; }
         rmdir "$MOUNT_SAVE_TMP"
+
     fi
 
 
@@ -329,6 +335,7 @@ else
     umount "$MOUNT_TMP" || panicExit  # remove union mount
     umount "$MOUNT_TMP" || panicExit  # remove tmpfs mount
     rmdir "$MOUNT_TMP"
+
 fi
 
 

--- a/copy/lib/platform-env
+++ b/copy/lib/platform-env
@@ -1287,3 +1287,57 @@ increaseActiveImageAndVolumeSize()
 
     return 0
 }
+
+
+###
+### SYSTEM STATE
+###
+
+testIsCurrentActiveImage()
+{
+    # required
+    local image_path
+
+    # local
+    local loop
+
+    testVariableDefinition MOUNT_SAVE || return $?
+
+    image_path=$1
+
+    if test -n "$image_path"; then
+        if test -f "$image_path"; then
+            if loop=`getImageLoop "$image_path"`; then
+                cat /proc/mounts \
+                    | tr -s '\t' ' ' \
+                    | cut -d ' ' -f 1-2 \
+                    | grep "^$loop $MOUNT_SAVE$" > /dev/null \
+                    && return 0
+            fi
+        fi
+    else
+        echo "Image path required" >&2
+    fi
+
+    return 1
+}
+
+testIsActiveImageSave()
+{
+    # local
+    local save_image_path
+
+    save_image_path=`getExistingSaveImagePath` || return $?
+    testIsCurrentActiveImage "$save_image_path"
+    return $?
+}
+
+testIsActiveImageActiveVolume()
+{
+    # local
+    local active_volume_image_path
+
+    active_volume_image_path=`getActiveVolumeImagePath` || return $?
+    testIsCurrentActiveImage "$active_volume_image_path"
+    return $?
+}

--- a/copy/lib/platform-env
+++ b/copy/lib/platform-env
@@ -133,6 +133,9 @@ updateBootOptions()
     local to_ram
     local unmount
     local save
+    local swap
+    local swap_wait
+    local no_active_fs
     local i
     local param
     local boot_device
@@ -151,6 +154,7 @@ updateBootOptions()
     save=save
     swap=swap
     swap_wait=swap-wait
+    no_active_fs=no-active-fs
 
     # empty string values
     BOOT_DEVICE=''
@@ -244,6 +248,11 @@ updateBootOptions()
             # swap wait
             $swap_wait=*        )   BOOT_SWAP_WAIT=${param#${swap_wait}=}
                                     ;;
+
+            # no active fs
+            $no_active_fs=0    )   BOOT_NO_ACTIVE_FS=0 ;;
+            $no_active_fs | \
+            $no_active_fs=1    )   BOOT_NO_ACTIVE_FS=1 ;;
         esac
     done
 


### PR DESCRIPTION
- Addresses issue #27 (_Add option to disable active Btrfs_)
## 

This commit adds a boot option, `BOOT_NO_ACTIVE_FS`, to disable Btrfs as the active data storage file system, falling back to storing data directly in the running system's tmpfs mount.
