### PR TITLE
wren (control script): Reformat usage table with separate RAM and Swap

### DIFF
--- a/copy/bin/wren
+++ b/copy/bin/wren
@@ -83,7 +83,7 @@ SYNOPSIS
     $APP_NAME set <VARIABLE> <VALUE>
     $APP_NAME status [all|device|platform|savefile|savename|savenames]
     $APP_NAME unset <VARIABLE>
-    $APP_NAME usage [all|active|device|memory] [-h|--human]
+    $APP_NAME usage [all|active|device|memory|ram|save|swap] [-h|--human]
 
 OPTIONS
 
@@ -91,7 +91,7 @@ OPTIONS
 
     +active     Allot additional memory to increase the platform's active
                 storage capacity (when using active storage).
-                
+
                 Can also be used to check if an increase is \"necessary\"
                 and/or \"safe\".
 
@@ -117,7 +117,7 @@ OPTIONS
                                 Use this in combination with a BYTE_COUNT to
                                 test the \"safe\" status of a specific size
                                 increment.
-                                
+
                                 Returns a binary mask exit code:
 
                                     0 = safe and necessary
@@ -138,7 +138,7 @@ OPTIONS
     get         Retrieve a stored variable value. Requires a variable name.
 
     grub        Perform a Grub configuration SUBCOMMAND.
-    
+
                 Requires one SUBCOMMAND from the following:
 
                     generate    Display a new Grub configuration to standard
@@ -156,21 +156,21 @@ OPTIONS
                 using the \"write\" SUBCOMMAND.
 
     list        Display stored variables and their values.
-    
+
                 Used primarily for debugging purposes.
-    
+
                 Accepts one SUBCOMMAND from the following:
 
                     all         Display all known variables, even if they
                                 are not set or stored.
 
     save        Save to disk (or a target save file).
-    
+
                 Accepts one OPTION in the following format:
-                
+
                     save savename=\"name_of_save_on_disk\"
                     save savefile=\"/path/to/save/file\"
-                    
+
                 If no OPTION is provided, set variables or system defaults
                 will be used.
 
@@ -188,7 +188,7 @@ OPTIONS
 
     status      Report on current platform state and expected paths/values.
                 Accepts an optional SUBCOMMAND to retrieve a specific state.
-                
+
                 Accepted SUBCOMMAND values are:
 
                     all         Display all states (default).
@@ -219,7 +219,8 @@ OPTIONS
 
                 Accepts the following optional SUBCOMMANDS:
 
-                    all         Display all values (default).
+                    all         Display all values (even those not currently
+                                applicable).
 
                     active      Display active data storage usage (if booted
                                 with save-to-ram).
@@ -228,12 +229,20 @@ OPTIONS
 
                     memory      Display memory usage. These values include
                                 combined RAM and swap. An extra \"unallocated\"
-                                field designates the amount of free memory
-                                that has not already been allocated for active
-                                data storage.
+                                field designates the amount of free memory that
+                                has not already been allocated for active data
+                                storage.
+
+                                Note: The \"memory\" SUBCOMMAND provides the
+                                same information as the \"total\" line in the
+                                \"all\" SUBCOMMAND output.
+
+                    ram         Display RAM memory usage.
 
                     save        Display save image usage (if booted directly
                                 from save file).
+
+                    swap        Display swap memory usage.
 "
 printUsage()
 {
@@ -336,6 +345,12 @@ setUsageStats()
     unset USAGE_SAVE_TOTAL
     unset USAGE_SAVE_USED
     unset USAGE_SAVE_FREE
+    unset USAGE_RAM_TOTAL
+    unset USAGE_RAM_USED
+    unset USAGE_RAM_FREE
+    unset USAGE_SWAP_TOTAL
+    unset USAGE_SWAP_USED
+    unset USAGE_SWAP_FREE
     unset USAGE_MEMORY_TOTAL
     unset USAGE_MEMORY_USED
     unset USAGE_MEMORY_FREE
@@ -382,7 +397,28 @@ EOF
     fi
 
     # memory (ram + swap) information
-    memory_info=$(free -bt | tail -n 1 | tr -s ' ' | cut -d ' ' -f 2-4) || return $?
+    memory_info=$(free -bt) || return $?
+    ram_info=$(echo "$memory_info" | grep -i '^mem:' | tr -s ' ' | cut -d ' ' -f 2-4) || return $?
+    swap_info=$(echo "$memory_info" | grep -i '^swap:' | tr -s ' ' | cut -d ' ' -f 2-4) || return $?
+    memory_info=$(echo "$memory_info" | tail -n 1 | tr -s ' ' | cut -d ' ' -f 2-4) || return $?
+    if test -n "$ram_info"; then
+        if IFS=' ' read a b c; then
+            USAGE_RAM_TOTAL=$a
+            USAGE_RAM_USED=$b
+            USAGE_RAM_FREE=$c
+        fi <<EOF
+$ram_info
+EOF
+    fi
+    if test -n "$swap_info"; then
+        if IFS=' ' read a b c; then
+            USAGE_SWAP_TOTAL=$a
+            USAGE_SWAP_USED=$b
+            USAGE_SWAP_FREE=$c
+        fi <<EOF
+$swap_info
+EOF
+    fi
     if test -n "$memory_info"; then
         if IFS=' ' read a b c; then
             USAGE_MEMORY_TOTAL=$a
@@ -420,7 +456,7 @@ case "$command" in
                     esac
                 fi
 
-                # show "all" variables or only those that are set 
+                # show "all" variables or only those that are set
                 test "$option" = all -o -n "$SAVENAME" && echo "savename=$SAVENAME"
                 test "$option" = all -o -n "$SAVEFILE" && echo "savefile=$SAVEFILE"
                 ;;
@@ -474,7 +510,7 @@ case "$command" in
                     panicExit "Option \"set\" requires a variable and a value"
                 fi
                 ;;
-                
+
     #
     # unset - unassign and remove stored variable values
     #
@@ -626,12 +662,9 @@ case "$command" in
                     option=$3
                 esac
 
-                # no option is the same as "all"
-                test -z "$option" && option=all
-
                 # check for invalid options
                 case "$option" in
-                    all | memory | active | save | device ) ;;
+                    '' | all | memory | ram | swap | active | save | device ) ;;
                     * ) panicExit "Unknown \"usage\" option: $option" ;;
                 esac
 
@@ -662,14 +695,21 @@ case "$command" in
 
                 # default table format
                 usage_format='%-8s %15s %15s %15s %15s\n'
+                unallocated_header=''
+                unallocated_unused=''
+                case "$option" in memory | all | '' )
+                    if test "$is_save_file" = 0; then
+                        unallocated_header=unallocated
+                        unallocated_unused=-
+                    fi
+                esac
 
                 # check for modifiers
                 case "$modifier" in -h | -human )
-                    usage_format='%-8s %7s %7s %7s %12s\n'
-                    USAGE_MEMORY_TOTAL=$(bytesToHuman "$USAGE_MEMORY_TOTAL")
-                    USAGE_MEMORY_USED=$(bytesToHuman "$USAGE_MEMORY_USED")
-                    USAGE_MEMORY_FREE=$(bytesToHuman "$USAGE_MEMORY_FREE")
-                    USAGE_MEMORY_UNALLOCATED=$(bytesToHuman "$USAGE_MEMORY_UNALLOCATED")
+                    usage_format='%-8s %7s %7s %7s %8s\n'
+                    if test -n "$unallocated_header"; then
+                        unallocated_header=unalloc
+                    fi
                     if test "$is_save_file" = 0; then
                         USAGE_ACTIVE_TOTAL=$(bytesToHuman "$USAGE_ACTIVE_TOTAL")
                         USAGE_ACTIVE_USED=$(bytesToHuman "$USAGE_ACTIVE_USED")
@@ -684,60 +724,105 @@ case "$command" in
                         USAGE_DEVICE_USED=$(bytesToHuman "$USAGE_DEVICE_USED")
                         USAGE_DEVICE_FREE=$(bytesToHuman "$USAGE_DEVICE_FREE")
                     fi
+                    USAGE_RAM_TOTAL=$(bytesToHuman "$USAGE_RAM_TOTAL")
+                    USAGE_RAM_USED=$(bytesToHuman "$USAGE_RAM_USED")
+                    USAGE_RAM_FREE=$(bytesToHuman "$USAGE_RAM_FREE")
+                    USAGE_SWAP_TOTAL=$(bytesToHuman "$USAGE_SWAP_TOTAL")
+                    USAGE_SWAP_USED=$(bytesToHuman "$USAGE_SWAP_USED")
+                    USAGE_SWAP_FREE=$(bytesToHuman "$USAGE_SWAP_FREE")
+                    USAGE_MEMORY_TOTAL=$(bytesToHuman "$USAGE_MEMORY_TOTAL")
+                    USAGE_MEMORY_USED=$(bytesToHuman "$USAGE_MEMORY_USED")
+                    USAGE_MEMORY_FREE=$(bytesToHuman "$USAGE_MEMORY_FREE")
+                    USAGE_MEMORY_UNALLOCATED=$(bytesToHuman "$USAGE_MEMORY_UNALLOCATED")
                 esac
 
                 # display usage table
-                unallocated_header=''
-                case "$option" in memory | all )
-                    test "$is_save_file" = 0 \
-                        && unallocated_header='unallocated'
-                esac
                 printf "$usage_format" '' 'total' 'used' 'free' "$unallocated_header"
 
+                case "$option" in all | '' )
+                    printf "%s\n" '[STORAGE]'
+                esac
+
+                # active
+                case "$option" in active | all | '' )
+                    if test "$option" = active \
+                        -o "$option" = all \
+                        -o "$is_save_file" = 0
+                    then
+                        printf "$usage_format" 'active:' \
+                            "$USAGE_ACTIVE_TOTAL" \
+                            "$USAGE_ACTIVE_USED" \
+                            "$USAGE_ACTIVE_FREE" \
+                            "$unallocated_unused"
+                    fi
+                esac
+
+                # save
+                case "$option" in save | all | '' )
+                    if test "$option" = save \
+                        -o "$option" = all \
+                        -o "$is_save_file" != 0
+                    then
+                        printf "$usage_format" 'save:' \
+                            "$USAGE_SAVE_TOTAL" \
+                            "$USAGE_SAVE_USED" \
+                            "$USAGE_SAVE_FREE" \
+                            "$unallocated_unused"
+                    fi
+                esac
+
+                # device
+                case "$option" in device | all | '' )
+                    if test "$option" = device \
+                        -o "$option" = all \
+                        -o "$device_mounted" != 0
+                    then
+                        printf "$usage_format" 'device:' \
+                            "$USAGE_DEVICE_TOTAL" \
+                            "$USAGE_DEVICE_USED" \
+                            "$USAGE_DEVICE_FREE" \
+                            "$unallocated_unused"
+                    fi
+                esac
+
+                case "$option" in all | '' )
+                    printf "%s\n" '[MEMORY]'
+                esac
+
+                # ram
+                case "$option" in ram | all | '' )
+                    printf "$usage_format" "ram:" \
+                        "$USAGE_RAM_TOTAL" \
+                        "$USAGE_RAM_USED" \
+                        "$USAGE_RAM_FREE" \
+                        "$unallocated_unused"
+                esac
+
+                # swap
+                case "$option" in swap | all | '' )
+                    printf "$usage_format" "swap:" \
+                        "$USAGE_SWAP_TOTAL" \
+                        "$USAGE_SWAP_USED" \
+                        "$USAGE_SWAP_FREE" \
+                        "$unallocated_unused"
+                esac
+
                 # memory
-                case "$option" in memory | all )
+                case "$option" in memory | all | '' )
+                    label='total:'
+                    test "$option" = memory \
+                        && label='memory:'
                     test "$is_save_file" = 0 \
                         && unallocated=$USAGE_MEMORY_UNALLOCATED \
-                        || unallocated=''
-                    printf "$usage_format" 'memory:' \
+                        || unallocated='-'
+                    printf "$usage_format" "$label" \
                         "$USAGE_MEMORY_TOTAL" \
                         "$USAGE_MEMORY_USED" \
                         "$USAGE_MEMORY_FREE" \
                         "$unallocated"
                 esac
-
-                # active
-                case "$option" in active | all )
-                    if test "$option" = active -o "$is_save_file" = 0; then
-                        printf "$usage_format" 'active:' \
-                            "$USAGE_ACTIVE_TOTAL" \
-                            "$USAGE_ACTIVE_USED" \
-                            "$USAGE_ACTIVE_FREE" \
-                            ""
-                    fi
-                esac
-
-                # save
-                case "$option" in save | all )
-                    if test "$option" = save -o "$is_save_file" != 0; then
-                        printf "$usage_format" 'save:' \
-                            "$USAGE_SAVE_TOTAL" \
-                            "$USAGE_SAVE_USED" \
-                            "$USAGE_SAVE_FREE" \
-                            ""
-                    fi
-                esac
-
-                # device
-                case "$option" in device | all )
-                    printf "$usage_format" 'device:' \
-                        "$USAGE_DEVICE_TOTAL" \
-                        "$USAGE_DEVICE_USED" \
-                        "$USAGE_DEVICE_FREE" \
-                        ""
-                esac
                 ;;
-                
+
     #
     # save - store active storage content to a save file
     #


### PR DESCRIPTION
- Addresses #25 (_Add optional RAM and Swap entries to "wren usage"_)
- Potential merge conflict #29 (_Option to disable active data file system_)
- Potential merge conflict #30 (_save.sh + wren: Add --no-snapshot option_)
## 

This commit reformats the `wren usage` output table with `[STORAGE]` and `[MEMORY]` headers and subdivides the previous `memory` line into `ram`, `swap`, and `total`. The line is still labeled `memory` if `wren usage memory` is called.

Additionally, the `unallocated` header has been shortened to `unalloc` in human readable mode and the `all` subcommand will additionally display the `active` or `save` lines even if they are not currently applicable.

**Sample Output:**

```
user@computer:~$ sudo wren usage -h
           total    used    free  unalloc
[STORAGE]
active:     1.0G    8.8M  885.9M        -
device:     5.9G    2.9G    2.6G        -
[MEMORY]
ram:        3.9G    1.3G    2.5G        -
swap:         0B      0B      0B        -
total:      3.9G    1.3G    2.5G     1.7G
```
